### PR TITLE
Add job for mysql

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ mariadb_service_group: mysql
 mariadb_deb_repository: "deb [arch=amd64,i386,ppc64el] http://mirrors.bestthaihost.com/mariadb/repo/10.1/ubuntu {{ ansible_distribution_release }} main"
 mariadb_apt_key_server: hkp://keyserver.ubuntu.com:80
 mariadb_apt_key_id: "0xF1656F24C74CD1D8"
+mariadb_mysql_apt_key_id: "5072E1F5"
 
 mariadb_mysql_apt_deb_filename: mysql-apt-config_0.8.0-1_all.deb
 mariadb_mysql_apt_deb: "https://dev.mysql.com/get/{{ mariadb_mysql_apt_deb_filename }}"

--- a/tasks/mariadb_build_slave.yml
+++ b/tasks/mariadb_build_slave.yml
@@ -51,6 +51,18 @@
     when: "'mariadb-master' in group_names"
     notify: Restart MariaDB Service
 
+  - name: Enable binlog on master (for MySQL version >= 5.7)
+    ini_file:
+      path: "{{ mariadb_mycnf_path }}"
+      section: mysqld
+      option: log_bin
+      value: ""
+    when: 
+      - mariadb_server_package_name == 'mysql-server' 
+      - mariadb_mysql_version >= 'mysql-5.7'
+      - "'mariadb-master' in group_names"
+    notify: Restart MariaDB Service
+
   - meta: flush_handlers
 
 

--- a/tasks/mariadb_pre.yml
+++ b/tasks/mariadb_pre.yml
@@ -31,6 +31,13 @@
 
 
 - block: # Prepare MySQL repository
+  - name: Add MySQL repository key
+    apt_key:
+      keyserver: "{{ mariadb_apt_key_server }}"
+      id: "{{ mariadb_mysql_apt_key_id }}"
+      state: present
+    when: mariadb_server_package_name == 'mysql-server'
+    
   - name: Set MySQL version before installing
     debconf:
       name: mysql-apt-config


### PR DESCRIPTION
1. c3cc400 Add mysql apt key when using mysql-server or else there will be error said 
  ```bash
  There were unauthenticated packages and -y was used without --allow-unauthenticated
  ```

2. a0a8796 For mysql-server with version >= `5.7`, need to add option `log_bin` (with no value) into `mysqld` section in file `my.cnf` at `{{ mariadb_mycnf_path }}` [reference](https://serverfault.com/questions/706699/enable-binlog-in-mysql-on-ubuntu#answer-796739)