### PR TITLE
Setup pymysql for db creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 mariadb_server_package_name: mariadb-server
 mariadb_packages:
   - "{{ mariadb_server_package_name }}"
-  - percona-xtrabackup-24
+  - "{{ mariadb_build_slave | bool | ternary('percona-xtrabackup-24', '') }}"
+  - "{{ ansible_python_version | default('3') is version('3', '<') | ternary('python-mysqldb', 'python3-pymysql') }}"
   - qpress
-  - python-mysqldb
   - mytop
 mariadb_service_name: mysql
 mariadb_service_user: mysql


### PR DESCRIPTION
When ansible runs against python3 it needs appropriate PyMySQL module.

Also there's no need in xtrabackup package where we have no slaves.