### PR TITLE
Use mariabackup for mariadb 10.3 and newer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,12 +6,14 @@ mariadb_packages:
   - qpress
   - mytop
 mariadb_backup_packages:
-  - percona-xtrabackup-24
+  - "{{ mariadb_version is version('10.3', '<') | ternary('percona-xtrabackup-24', 'mariadb-backup') }}"
+mariadb_backup_binary: "{{ mariadb_version is version('10.3', '<') | ternary('innobackupex', 'mariabackup') }}"
 mariadb_service_name: mysql
 mariadb_service_user: mysql
 mariadb_service_group: mysql
 
-mariadb_deb_repository: "deb [arch=amd64] http://sgp1.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu {{ ansible_distribution_release }} main"
+mariadb_version: 10.3
+mariadb_deb_repository: "deb [arch=amd64] http://sgp1.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
 mariadb_apt_key_server: hkp://keyserver.ubuntu.com:80
 mariadb_apt_key_id: "0xF1656F24C74CD1D8"
 mariadb_mysql_apt_key_id: "5072E1F5"
@@ -54,6 +56,7 @@ mariadb_root_password: CHANGEME
 mariadb_replicate_username: repl
 mariadb_replicate_password: CHANGEME
 mariadb_decompress_memory: 1G
+mariadb_slave_port: "{{ ansible_port | default(22) }}"
 
 # Sample to add users
 # mariadb_users:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,11 @@
 mariadb_server_package_name: mariadb-server
 mariadb_packages:
   - "{{ mariadb_server_package_name }}"
-  - "{{ mariadb_build_slave | bool | ternary('percona-xtrabackup-24', '') }}"
   - "{{ ansible_python_version | default('3') is version('3', '<') | ternary('python-mysqldb', 'python3-pymysql') }}"
   - qpress
   - mytop
+mariadb_backup_packages:
+  - percona-xtrabackup-24
 mariadb_service_name: mysql
 mariadb_service_user: mysql
 mariadb_service_group: mysql

--- a/tasks/mariadb_build_slave.yml
+++ b/tasks/mariadb_build_slave.yml
@@ -82,11 +82,11 @@
 - block: # Transfer data and configuration files
 
   - name: Copy file from master to slave
-    shell: "innobackupex --user=root --password={{ mariadb_root_password }}
-      --compress --compress-threads=8 --stream=xbstream --parallel=4 ./ |
-      ssh -q -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=3
+    shell: "{{ mariadb_backup_binary }} --user=root --password={{ mariadb_root_password }}
+      --compress --compress-threads=8 --stream=xbstream --parallel=4 {{ (mariadb_backup_binary == 'mariabackup') | ternary('--backup', './') }} |
+      ssh -p {{ mariadb_slave_port }} -q -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=3
       {{ hostvars[item]['ansible_host'] }}
-      'xbstream -x -C {{ mariadb_data_path }}'"
+      '{{ (mariadb_backup_binary == 'mariabackup') | ternary('mbstream', 'xbstream') }} -x -C {{ mariadb_data_path }}'"
     async: 3600
     poll: 0
     with_items: "{{ groups['mariadb-slave'] }}"
@@ -100,7 +100,7 @@
     retries: 720
 
   - name: Copy mysql configuration file from master to slave
-    shell: "scp -r {{ mariadb_etc_path }}/*
+    shell: "scp -P {{ mariadb_slave_port }} -r {{ mariadb_etc_path }}/*
       {{ hostvars[item]['ansible_host'] }}:{{ mariadb_etc_path }}/"
     with_items: "{{ groups['mariadb-slave'] }}"
   when: "'mariadb-master' in group_names"
@@ -108,7 +108,7 @@
 
 - block: # Prepare data files
   - name: Decompress database files
-    shell: "innobackupex --decompress {{ mariadb_data_path }}"
+    shell: "{{ mariadb_backup_binary }} --decompress --remove-original --target-dir={{ mariadb_data_path }}"
     async: 7200
     poll: 0
     register: mariadb_slave_decompress
@@ -121,8 +121,8 @@
     retries: 1440
 
   - name: Apply log database files
-    shell: "innobackupex --apply-log --use-memory {{ mariadb_decompress_memory }}
-      {{ mariadb_data_path }}"
+    shell: "{{ mariadb_backup_binary }} {{ (mariadb_backup_binary == 'mariabackup') | ternary('--prepare', '--apply-log') }}
+      --use-memory {{ mariadb_decompress_memory }} --target-dir={{ mariadb_data_path }}"
     async: 3600
     poll: 0
     register: mariadb_slave_apply_log
@@ -198,9 +198,4 @@
       login_user: root
       login_password: "{{ mariadb_root_password }}"
     when: "mariadb_slave_replication | bool"
-  when: "'mariadb-slave' in group_names"
-
-- block: # Clean compress files
-  - name: Delete all .qp compress files
-    shell: "find {{ mariadb_data_path }} -name '*.qp' | xargs rm -rf"
   when: "'mariadb-slave' in group_names"

--- a/tasks/mariadb_install.yml
+++ b/tasks/mariadb_install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install MariaDB and Percona ExtraBackup
   apt:
-     pkg: "{{ mariadb_packages }}"
+     pkg: "{{ mariadb_build_slave | bool | ternary(mariadb_packages + mariadb_backup_packages, mariadb_packages) }}"
      state: latest
      update_cache: yes


### PR DESCRIPTION
Backup/restore commands were adopted in order to suit both innobackupex
and mariabackup as
MariaDB 10.3 and newer are incompatible with innobackupex.

This also resolves problem when apt is not accepting empty items.